### PR TITLE
Fix scene transitions.

### DIFF
--- a/lib/transition.js
+++ b/lib/transition.js
@@ -40,6 +40,7 @@ export default class TransitionScene extends Scene {
 	draw(ctx) {
 		ctx.save();
 
+		ctx.clearRect(0, 0, this.size.x, this.size.y);
 		this.fromScene.draw(this.fromBuffer.ctx);
 		this.toScene.draw(this.toBuffer.ctx);
 		this.performTransition(ctx);


### PR DESCRIPTION
When using an easing function that goes out of bounds (elastic), the background would not reset to any sensible clean area.